### PR TITLE
Te copy tweaks

### DIFF
--- a/mauiday.config.mjs
+++ b/mauiday.config.mjs
@@ -1,8 +1,8 @@
 
 
 export const config = {
-    SITE_TITLE: '.NET MAUI Day | A free, one-day event dedicated to the latest in cross-platform development with .NET MAUI!', // Title of the site
-    SITE_DESCRIPTION: 'A free, one-day event dedicated to the latest in cross-platform development with .NET MAUI! Join global experts for sessions, live discussions, and networking on the cutting-edge .NET MAUI ecosystem. Connect, learn, and explore with developers worldwide!', // Description of the site
+    SITE_TITLE: '.NET MAUI Day | An in-person, one-day event dedicated to the latest in cross-platform development with .NET MAUI!', // Title of the site
+    SITE_DESCRIPTION: 'An in-person, one-day event dedicated to the latest in cross-platform development with .NET MAUI! Join global experts for sessions, live discussions, and networking on the cutting-edge .NET MAUI ecosystem. Connect, learn, and explore with developers worldwide!', // Description of the site
     SITE_ROOT: 'https://mauiday.net', // Root URL of the site
     BLUESKY_LINK: 'https://bsky.app/profile/mauiday.net', // Link to the BlueSky profile
     GITHUB_LINK: 'https://github.com/MauiDay', // Link to the GitHub profile

--- a/src/components/hero.astro
+++ b/src/components/hero.astro
@@ -20,8 +20,9 @@ const { ticketUrl, headline, hasCfs } = config;
       The Conference with a Focus on .NET MAUI 🏝️
     </h1>
     <p class="text-white text-lg mt-6 mb-12">
-      .NET MAUI day is a one-day, free, event filled with sessions that have to
-      do with cross-platform development using, you guessed it, .NET MAUI. Speakers from all around the world will be there to present about the
+      .NET MAUI day is a one-day, in-person event filled with sessions that have to
+      do with cross-platform development using, you guessed it, .NET MAUI. Its also free! Speakers 
+      from all around the world will be there to present about the
       latest and greatest in the .NET MAUI ecosystem, as well as being in the
       “hallway track” so you can talk to them, discuss and ask questions.
     </p>

--- a/src/pages/diversity-statement.astro
+++ b/src/pages/diversity-statement.astro
@@ -14,20 +14,33 @@ const { codeOfConductMain, codeOfConductSecondary } = config;
         <h1 class="text-4xl mb-8 text-brand-dark font-bold">
           A Statement on Diversity, Equity, and Inclusion
         </h1>
-        <p class="mt-4">
-          We need to acknowledge a clear issue—the lack of diversity in our speaker lineup. Despite our efforts to assemble a broad range of voices, we fell short, and our lineup isn't a true representation of the makeup of our community. We tried multiple channels in order to widen the net of submissions and give opportunity to all but we did not succeed in our attempts. As this is the first iteration of this event, the speaker pool taking availability and clashes with other events into consideration was smaller than we would have liked, but that is not an excuse. We are committed to improving, and we are taking concrete steps to ensure future events reflect a more diverse and representative lineup.
-        </p>
+        <p class="mt-4">We screwed up. We'll do better next time.</p>
+
+        <p class="mt-4">We need to acknowledge a clear issue—the lack of diversity in our speaker lineup. Despite our efforts to assemble a broad range of voices, we fell short. Whilst we're proud to have each and everyone of our speaks join us in London, and appreciate them all for giving up their time to speak at our event at their own cost, our lineup isn't a true representation of the makeup of our community.</p>
+
+        <p class="mt-4">We tried multiple channels in order to widen the net of submissions and give opportunity to all but we did not succeed in our attempts. As this is the first iteration of the UK outing for MAUI Day, and taking availability and clashes with other events into consideration, the speaker pool was smaller than we would have liked. Not being able to offer any speaker support package due to funding had more of an impact than we'd expected.</p>
+
+        <p class="mt-4">But that is not an excuse.</p>
+
+        <p class="mt-4">We are committed to improving. and we are taking concrete steps to ensure future events reflect a more diverse and representative lineup. We are committed to creating a .NET MAUI focused conference in the UK that uplifts others, and supports them to go onto bigger things. We are committed to making sure that you feel represented.</p>
+
+        <p class="mt-4">If we can't do this at future outings, they likely won't happen.</p>
         <br/>
+
         <h2 class="text-3xl mb-8 text-brand-dark font-bold">What are we doing about it?</h2>
         <p class="mt-4">
-          Every setback is an opportunity to learn. We now have greater awareness of additional networks, contacts, and strategies to expand our reach and create more opportunities for underrepresented voices. We also recognize that timing plays a crucial role—giving potential speakers enough notice is essential for ensuring they can participate. These factors will be a core focus as we plan future events.
+          Every setback is an opportunity to learn.
         </p>
-        <p class="mt-4">
-          While this year’s lineup does not reflect the diversity we had hoped for, it has reinforced our commitment to change. Representation is vital, and we are dedicated to making tangible improvements in how we recruit and support speakers. We plan to reach out to potential speakers sooner, but also reaching out to communities and meetups to encourage new speakers to take a step up and submit conference talks at ours and other events. We will of course be open to suggestions and feedback from our community on how we can improve for future events.
-        </p>
-        <p class="mt-4">
-         Thank you!
-        </p>
+        <p class="mt-4">We now have greater awareness of additional networks, contacts, and strategies to expand our reach and create more opportunities for more voices. We also recognize that timing plays a crucial role—giving potential speakers enough notice is essential for ensuring they can participate.</p>
+
+        <p class="mt-4">These factors will be a core focus as we plan future events.</p>
+
+        <p class="mt-4">While this year’s UK lineup does not reflect the diversity we had hoped for, it has reinforced our commitment to change. Representation is vital, and we are dedicated to making tangible improvements in how we recruit and support speakers.</p>
+
+        <p class="mt-4">We plan to reach out to potential speakers sooner, but also reaching out to communities and meetups to encourage new speakers to take a step up and submit conference talks at ours and other events. We will of course be open to suggestions and feedback from our community on how we can improve in the years to come.</p>
+
+        <p class="mt-4">Thank you!</p>
+        
       </div>
     </div>
   </section>

--- a/src/pages/diversity-statement.astro
+++ b/src/pages/diversity-statement.astro
@@ -16,7 +16,7 @@ const { codeOfConductMain, codeOfConductSecondary } = config;
         </h1>
         <p class="mt-4">We screwed up. We'll do better next time.</p>
 
-        <p class="mt-4">We need to acknowledge a clear issue—the lack of diversity in our speaker lineup. Despite our efforts to assemble a broad range of voices, we fell short. Whilst we're proud to have each and everyone of our speaks join us in London, and appreciate them all for giving up their time to speak at our event at their own cost, our lineup isn't a true representation of the makeup of our community.</p>
+        <p class="mt-4">We need to acknowledge a clear issue—the lack of diversity in our speaker lineup. Despite our efforts to assemble a broad range of voices, we fell short. Whilst we're proud to have each and every one of our speaks join us in London, and appreciate them all for giving up their time to speak at our event at their own cost, our lineup isn't a true representation of the makeup of our community.</p>
 
         <p class="mt-4">We tried multiple channels in order to widen the net of submissions and give opportunity to all but we did not succeed in our attempts. As this is the first iteration of the UK outing for MAUI Day, and taking availability and clashes with other events into consideration, the speaker pool was smaller than we would have liked. Not being able to offer any speaker support package due to funding had more of an impact than we'd expected.</p>
 

--- a/src/pages/diversity-statement.astro
+++ b/src/pages/diversity-statement.astro
@@ -16,7 +16,7 @@ const { codeOfConductMain, codeOfConductSecondary } = config;
         </h1>
         <p class="mt-4">We screwed up. We'll do better next time.</p>
 
-        <p class="mt-4">We need to acknowledge a clear issue—the lack of diversity in our speaker lineup. Despite our efforts to assemble a broad range of voices, we fell short. Whilst we're proud to have each and every one of our speaks join us in London, and appreciate them all for giving up their time to speak at our event at their own cost, our lineup isn't a true representation of the makeup of our community.</p>
+        <p class="mt-4">We need to acknowledge a clear issue—the lack of diversity in our speaker lineup. Despite our efforts to assemble a broad range of voices, we fell short. Whilst we're proud to have each and every one of our speakers join us in London, and appreciate them all for giving up their time to speak at our event at their own cost, our lineup isn't a true representation of the makeup of our community.</p>
 
         <p class="mt-4">We tried multiple channels in order to widen the net of submissions and give opportunity to all but we did not succeed in our attempts. As this is the first iteration of the UK outing for MAUI Day, and taking availability and clashes with other events into consideration, the speaker pool was smaller than we would have liked. Not being able to offer any speaker support package due to funding had more of an impact than we'd expected.</p>
 

--- a/src/pages/diversity-statement.astro
+++ b/src/pages/diversity-statement.astro
@@ -22,7 +22,7 @@ const { codeOfConductMain, codeOfConductSecondary } = config;
 
         <p class="mt-4">But that is not an excuse.</p>
 
-        <p class="mt-4">We are committed to improving. and we are taking concrete steps to ensure future events reflect a more diverse and representative lineup. We are committed to creating a .NET MAUI focused conference in the UK that uplifts others, and supports them to go onto bigger things. We are committed to making sure that you feel represented.</p>
+        <p class="mt-4">We are committed to improving. We are taking concrete steps to ensure future events reflect a more diverse and representative lineup. We are committed to creating a .NET MAUI focused conference in the UK that uplifts others, and supports them to go onto bigger things. We are committed to making sure that you feel represented.</p>
 
         <p class="mt-4">If we can't do this at future outings, they likely won't happen.</p>
         <br/>


### PR DESCRIPTION
This has not been run locally. . . but should be fine.

- Updates diversity statement to make it blunter up front, and breaks it up for readability.
- Deprioritises the word free in the homepage Hero.
- Removes free from the site meta

Chat in the Slack around reasoning for the changes.