### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      frontend-stack:
+        patterns:
+          - "astro"
+          - "@astrojs/*"
+          - "tailwindcss"
+          - "@tailwindcss/*"
+          - "vite"
+          - "@vitejs/*"
+          - "postcss"
+          - "autoprefixer"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- add Dependabot weekly npm update checks for the root package manifest and lockfile
- add Dependabot weekly GitHub Actions update checks
- group Astro/Tailwind/Vite-related frontend packages and all Actions updates for easier review

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "YAML syntax OK"'
- git diff --check