### PR TITLE
Fix location page nav layering

### DIFF
--- a/src/components/hero.astro
+++ b/src/components/hero.astro
@@ -11,15 +11,15 @@ const { ticketUrl, headline, hasCfs, badge } = config;
   class="relative bg-cover bg-center hero h-full"
 > 
 
-  <div class="absolute inset-0 bg-black/50"></div>
+  <div class="absolute inset-0 bg-black/50 pointer-events-none"></div>
   <div
-    class="absolute inset-0 z-0"
+    class="absolute inset-0 z-0 pointer-events-none"
     style={{
       background: "radial-gradient(125% 125% at 50% 10%, transparent 40%, #C93CAD77 100%)",
     }}
   />
   <div
-    class="absolute inset-0 z-0"
+    class="absolute inset-0 z-0 pointer-events-none"
     style={{
       backgroundImage: `
         linear-gradient(to right, #e7e5e411 1px, transparent 1px),
@@ -64,7 +64,7 @@ const { ticketUrl, headline, hasCfs, badge } = config;
     }}
   />
 
-  <div class="container z-100 relative max-w-4xl mx-auto px-8 py-40 flex flex-col items-center h-full">
+  <div class="container z-10 relative max-w-4xl mx-auto px-8 py-40 flex flex-col items-center h-full">
    
     <img class="size-40 mb-10" src={`/images/editions/${badge}`} alt="MAUI Day Logo" />
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -68,6 +68,7 @@
   position:absolute;
   inset:0;
   z-index: 0;
+  pointer-events: none;
   background:
     linear-gradient(90deg, rgba(0,0,0,.75) 0%, rgba(0,0,0,.35) 60%, rgba(0,0,0,.15) 100%);
 }


### PR DESCRIPTION
## Summary
- Lower the hero content stacking level below the fixed navigation
- Disable pointer events on decorative hero overlays so the header receives hover/click events

## Validation
- `npm run build`
- Browser hit-tested `/skopje/` and `/cologne/` header areas to confirm the topmost elements are inside the nav
- Verified the mobile menu toggle still opens on a location page