### PR TITLE
Point location page Home links to root

### DIFF
--- a/src/components/navigation.astro
+++ b/src/components/navigation.astro
@@ -8,7 +8,7 @@ const {
   landing = false,
 } = Astro.props;
 const confConfig = eventConfig ?? await loadConfig();
-const homeHref = landing ? "/" : eventBasePath || "/";
+const homeHref = "/";
 const sectionHref = (id: string) => `${eventBasePath || ""}/#${id}`;
 ---
 


### PR DESCRIPTION
## Summary
- Change the shared navigation Home link to always point to `/`
- Keeps location-page section links pointing at their event-specific anchors

## Validation
- `npm run build`
- Checked generated `/skopje/` and `/cologne/` nav Home links; both desktop and mobile Home links render as `/`