### PR TITLE
Add MAUI Day history draft

### DIFF
--- a/src/pages/archive/index.astro
+++ b/src/pages/archive/index.astro
@@ -26,7 +26,7 @@ const hasBadgeEvents = eventsWithThumbs.some((event) => event.badgeImage);
       <p class="text-brand-extra font-bold mb-4 text-xl font-header uppercase">Looking Back</p>
       <h2 class="text-white text-4xl uppercase font-header font-bold mb-4">Event Archive</h2>
       <p class="text-white text-base text-md mb-12">
-        Browse past MAUI Day and XamExpertDay events.
+        Browse past MAUI Day and XamExpertDay events, or <a href="/history" class="text-brand-extra font-bold hover:underline">read the backstory</a>.
       </p>
 
       {hasBadgeEvents && (

--- a/src/pages/history.astro
+++ b/src/pages/history.astro
@@ -1,0 +1,162 @@
+---
+import Layout from "../layouts/Layout.astro";
+---
+
+<Layout
+  pageTitle="The Story Behind MAUI Day | MAUI Day"
+  pageDescription="How MAUI Day grew from Expert Day for Xamarin into a community event around the world."
+>
+  <section class="relative overflow-hidden bg-brand-dark pt-40 pb-24">
+    <div
+      class="absolute inset-0"
+      style={{
+        background:
+          "radial-gradient(circle at top left, rgba(230, 102, 204, 0.22), transparent 32%), radial-gradient(circle at bottom right, rgba(151, 128, 229, 0.18), transparent 36%)",
+      }}
+    />
+    <div
+      class="absolute inset-0 opacity-30"
+      style={{
+        backgroundImage:
+          "linear-gradient(to right, rgba(217, 238, 255, 0.12) 1px, transparent 1px), linear-gradient(to bottom, rgba(217, 238, 255, 0.12) 1px, transparent 1px)",
+        backgroundSize: "28px 28px",
+      }}
+    />
+
+    <div class="container relative z-10 max-w-5xl mx-auto px-4">
+      <a href="/archive" class="inline-flex items-center gap-2 text-brand-extra hover:text-white transition-colors text-sm font-bold mb-10">
+        <i class="fa-solid fa-arrow-left"></i>
+        Back to Archive
+      </a>
+
+      <div class="max-w-3xl">
+        <p class="text-brand-extra font-bold mb-4 text-xl font-header uppercase">From XamExpertDay to MAUI Day</p>
+        <h1 class="text-white text-4xl md:text-6xl uppercase font-header font-bold mb-6 leading-tight">
+          The Story Behind MAUI Day
+        </h1>
+        <p class="text-brand-light/85 text-lg md:text-xl leading-relaxed">
+          A small community event that started in Cologne, moved from Xamarin to .NET MAUI, and kept growing because people kept showing up.
+        </p>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mt-12">
+        <div class="rounded-3xl border border-white/10 bg-white/5 p-5">
+          <p class="text-brand-extra text-sm font-bold uppercase mb-2">Started</p>
+          <p class="text-white text-3xl font-header font-bold">2017</p>
+        </div>
+        <div class="rounded-3xl border border-white/10 bg-white/5 p-5">
+          <p class="text-brand-extra text-sm font-bold uppercase mb-2">First home</p>
+          <p class="text-white text-3xl font-header font-bold">Cologne</p>
+        </div>
+        <div class="rounded-3xl border border-white/10 bg-white/5 p-5">
+          <p class="text-brand-extra text-sm font-bold uppercase mb-2">Always</p>
+          <p class="text-white text-3xl font-header font-bold">Free</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="bg-white py-20">
+    <div class="container max-w-5xl mx-auto px-4">
+      <article class="max-w-3xl mx-auto text-gray-700 text-lg leading-8">
+        <p class="text-2xl text-brand-dark font-header font-bold leading-snug mb-8">
+          MAUI Day did not start with a big plan. Like many good community things, it mostly started with a few people thinking: we can probably make this useful, and maybe even fun.
+        </p>
+
+        <p class="mt-6">
+          Back in 2017 this was still the Xamarin era. Xamarin had recently become part of Microsoft, and there was an initiative called Xamarin Dev Days. If I remember correctly, it was kind of an event-in-a-box setup. The schedule, slides, and overall format were provided, and you mostly needed people to present it locally.
+        </p>
+
+        <p class="mt-6">
+          That was great, but around us we noticed people were looking for something a bit more in-depth. At that point Glenn Versweyveld, Thomas Burkhart, Tobias Hoppenthaler, Kerry Lothrop, and I, Gerald Versluis, had already been working with Xamarin for a while. So instead of running another intro-style event, we decided to make something more focused on people who were already building apps and wanted to go deeper.
+        </p>
+
+        <p class="mt-6">
+          We knew some people at Microsoft and checked what we could and could not do with the naming. The advice was basically: don't start the name with Xamarin, but otherwise you should be fine. So the first version became <strong class="text-brand-dark">Expert Day for Xamarin</strong>, which later got shortened to <strong class="text-brand-dark">XamExpertDay</strong>.
+        </p>
+
+        <div class="my-10 rounded-3xl border-l-4 border-brand-extra bg-brand-light/40 p-6">
+          <p class="text-brand-dark font-header text-2xl font-bold leading-snug">
+            The reason the first events happened in Cologne was not because of some big strategic decision. Three of the original crew were German, some of them had contacts at the Microsoft office there, and we were able to use that venue. That was it. Very glamorous.
+          </p>
+        </div>
+
+        <p class="mt-6">
+          It started small. Maybe 30 people the first time. Then around 50. Then eventually we filled the venue with about 100 people. For a free community event, that already felt pretty amazing.
+        </p>
+
+        <p class="mt-6">
+          Over the years we were lucky enough to have at least one "bigger" name join us for most editions. Although, to be fair, it was not only luck. We often planned the event close to another bigger conference, so speakers who were already in the area could make an extra stop with us. That helped a lot.
+        </p>
+
+        <p class="mt-6">
+          Then COVID happened. We did one or two online editions, and those turned out to be a huge success. In a way, those online events also pushed me more into creating videos and helped kick off what became my YouTube channel. After that, Xamarin became .NET MAUI, and naturally we moved with it. XamExpertDay became MAUI Day.
+        </p>
+
+        <p class="mt-6">
+          The people involved also changed over time. Some of the original crew moved on to other things, which is totally normal, and luckily new people joined in. That has always been part of the charm of this event. It is not one big machine. It is a group of people who care about the community and make things happen where they can.
+        </p>
+
+        <p class="mt-6">
+          For years people would come up to me and say: "We should do a MAUI Day in..." And I always gave the same answer: let's talk. You can use the branding, I want to keep some control over what it is, but I am happy to help and you can run things locally. Most of those conversations stayed conversations.
+        </p>
+
+        <h2 class="text-brand-dark text-3xl md:text-4xl uppercase font-header font-bold mt-14 mb-6">
+          Until London.
+        </h2>
+
+        <p class="mt-6">
+          At one of the Cologne editions, some people from the UK were in the audience and said: we should do this in London. Same answer from me: let's talk. But this time they actually followed through. Tony Edwards, Shaun Lawrence, and Clifford Agius helped turn that idea into a real event, and London was a huge success.
+        </p>
+
+        <p class="mt-6">
+          Maybe because London is easy to reach, maybe because the timing was right, maybe both. Cologne was already pretty easy to "sell out", in quotes because MAUI Day has always been free, but London was something else. We had a big waitlist and a lot of excitement around it.
+        </p>
+
+        <p class="mt-6">
+          That free part is important too. MAUI Day has always been a free event. Sponsors have been kind enough to help with things like lunch, licenses, products to give away, venues, and all the practical things that make a day like this possible. That support is a big reason we can keep it accessible.
+        </p>
+
+        <p class="mt-6">
+          From London, some of that crew became more involved in the core group as well. Later we got in touch with Jakub and a friend he was working with at the time, and they wanted to bring MAUI Day to Poland. The first attempt did not work out, but we tried again. We planned it close to Update Conference in Krakow, so David and I were already there, and this time it happened.
+        </p>
+
+        <p class="mt-6">
+          And now it keeps growing in a very organic way. Through people in the community we got connected with folks in Macedonia who are eager to build more community traction there, both in general and around .NET MAUI specifically. That edition will probably be a little different from the ones we have done so far, but that is also the point. MAUI Day should fit the local community, not the other way around.
+        </p>
+
+        <h2 class="text-brand-dark text-3xl md:text-4xl uppercase font-header font-bold mt-14 mb-6">
+          Why it works
+        </h2>
+
+        <p class="mt-6">
+          I think the real power of MAUI Day is that it is informal. It is not huge. Sessions are not recorded. People talk openly. Speakers, attendees, community members, and people from the product teams are all in the same room. Everyone feels a bit more free to ask honest questions, share what works, and also share what does not.
+        </p>
+
+        <p class="mt-6">
+          That direct line is incredibly valuable. People get to hear what is being worked on, and at the same time we get honest feedback from people who are building real apps with this technology every day.
+        </p>
+
+        <p class="mt-6">
+          That is what makes it special to me. It is useful, but it is also just a lot of fun. People travel from all over the world, not only to speak, but also to attend. That still blows my mind a little bit.
+        </p>
+
+        <p class="mt-6">
+          So no, there was never a grand master plan behind the locations or the growth of MAUI Day. It just happened step by step, with good people, good timing, and a community that keeps showing up.
+        </p>
+
+        <div class="mt-14 rounded-3xl bg-brand-dark p-6 md:p-8 text-white shadow-xl">
+          <p class="text-brand-extra font-header font-bold uppercase mb-3">PS</p>
+          <p class="text-brand-light/90 leading-8">
+            This story does not mention every single name, but that does not mean anyone is forgotten. MAUI Day has always been shaped by everyone who showed up along the way. Some were there from the start, some joined for a while, some came in later and are still here today. All of them left something with us, and we are grateful for every bit of it.
+          </p>
+        </div>
+
+        <footer class="mt-12 border-t border-gray-200 pt-8">
+          <p class="text-brand-dark text-xl font-header font-bold">Gerald Versluis</p>
+          <p class="text-gray-500">Co-founder of MAUI Day</p>
+        </footer>
+      </article>
+    </div>
+  </section>
+</Layout>

--- a/src/pages/history.astro
+++ b/src/pages/history.astro
@@ -138,7 +138,7 @@ import Layout from "../layouts/Layout.astro";
         </figure>
 
         <p class="mt-6">
-          That free part is important too. MAUI Day has always been a free event. Sponsors have been kind enough to help with things like lunch, licenses, products to give away, venues, and all the practical things that make a day like this possible. That support is a big reason we can keep it accessible.
+          That free part is important too. MAUI Day has always been a free event, and that only works because sponsors have been kind enough to help with things like lunch, venues, licenses, products to give away, and all the practical things that make a day like this possible. Huge shoutout to everyone who supported us over the years. It is not always the most visible part of the event, but it is a big reason we can keep it accessible for everyone.
         </p>
 
         <p class="mt-6">
@@ -176,6 +176,18 @@ import Layout from "../layouts/Layout.astro";
         <p class="mt-6">
           So no, there was never a grand master plan behind the locations or the growth of MAUI Day. It just happened step by step, with good people, good timing, and a community that keeps showing up.
         </p>
+
+        <figure class="my-10 overflow-hidden rounded-3xl border border-gray-200 bg-gray-50 shadow-xl">
+          <img
+            src="https://raw.githubusercontent.com/MauiDay/gallery/main/medium/london-2025/20250314_mauidaylondon_009jpg_54405070661_o.jpg"
+            alt="MAUI Day London 2025 team members Shaun Lawrence, Maddy Montaquila, Gerald Versluis, Clifford Agius, Tony Edwards, Tobias Hoppenthaler, and Matt Lacey standing together."
+            class="w-full object-cover"
+            loading="lazy"
+          />
+          <figcaption class="px-5 py-4 text-sm text-gray-500">
+            Some of the MAUI Day London 2025 crew. From left to right: Shaun Lawrence, Maddy Montaquila, Gerald Versluis, Clifford Agius, Tony Edwards, Tobias Hoppenthaler, and Matt Lacey. Turns out the secret ingredient is mostly good people who keep saying yes.
+          </figcaption>
+        </figure>
 
         <div class="mt-14 rounded-3xl bg-brand-dark p-6 md:p-8 text-white shadow-xl">
           <p class="text-brand-extra font-header font-bold uppercase mb-3">PS</p>

--- a/src/pages/history.astro
+++ b/src/pages/history.astro
@@ -118,6 +118,10 @@ import Layout from "../layouts/Layout.astro";
         </p>
 
         <p class="mt-6">
+          And while we are talking about things that make MAUI Day feel like MAUI Day, a special shoutout has to go to Steven Thewissen, our resident graphic designer. If something needs to look good, whether it is the socials, the website, the badges, or anything else we suddenly decide should probably not look like a developer made it, Steven is usually the person making that happen.
+        </p>
+
+        <p class="mt-6">
           From London, some of that crew became more involved in the core group as well. Later we got in touch with Jakub Florkowski and Michał Pobuta, who really spearheaded bringing MAUI Day to Kraków, Poland. We planned it close to Update Conference in Kraków, so David and I were already there, and that helped make it happen.
         </p>
 

--- a/src/pages/history.astro
+++ b/src/pages/history.astro
@@ -118,7 +118,11 @@ import Layout from "../layouts/Layout.astro";
         </p>
 
         <p class="mt-6">
-          From London, some of that crew became more involved in the core group as well. Later we got in touch with Jakub and a friend he was working with at the time, and they wanted to bring MAUI Day to Poland. The first attempt did not work out, but we tried again. We planned it close to Update Conference in Krakow, so David and I were already there, and this time it happened.
+          From London, some of that crew became more involved in the core group as well. Later we got in touch with Jakub Florkowski and Michał Pobuta, who really spearheaded bringing MAUI Day to Kraków, Poland. We planned it close to Update Conference in Kraków, so David and I were already there, and that helped make it happen.
+        </p>
+
+        <p class="mt-6">
+          This was exactly what I had always hoped for when I said "let's talk." Not just taking the same event and dropping it into another city, but bringing in the local community to shape it with us. People who know the place, know the audience, and care enough to make it feel like it belongs there. That matters, because the best part of MAUI Day is not just the talks, the venue, or even the badges. It is the vibe in the room. The informal setting, the honest conversations, the feeling that everyone is there for the same reason. You can try to bring that to another city, but you never really know if it will click in the same way. In Kraków it did, and I think Jakub and Michał being there with their local community is a big reason why. It made bringing that MAUI Day feeling to Poland feel natural.
         </p>
 
         <p class="mt-6">

--- a/src/pages/history.astro
+++ b/src/pages/history.astro
@@ -85,6 +85,18 @@ import Layout from "../layouts/Layout.astro";
           It started small. Maybe 30 people the first time. Then around 50. Then eventually we filled the venue with about 100 people. For a free community event, that already felt pretty amazing.
         </p>
 
+        <figure class="my-10 overflow-hidden rounded-3xl border border-gray-200 bg-gray-50 shadow-xl">
+          <img
+            src="https://raw.githubusercontent.com/MauiDay/gallery/main/medium/cologne-2017/xamexpertday-cologne-2017-001.jpg"
+            alt="A small audience seated in a low-key room at the first XamExpertDay event in Cologne in 2017."
+            class="w-full object-cover"
+            loading="lazy"
+          />
+          <figcaption class="px-5 py-4 text-sm text-gray-500">
+            The first XamExpertDay in Cologne, 2017. Smaller audience, low key, and still very much figuring things out.
+          </figcaption>
+        </figure>
+
         <p class="mt-6">
           Over the years we were lucky enough to have at least one "bigger" name join us for most editions. Although, to be fair, it was not only luck. We often planned the event close to another bigger conference, so speakers who were already in the area could make an extra stop with us. That helped a lot.
         </p>
@@ -112,6 +124,18 @@ import Layout from "../layouts/Layout.astro";
         <p class="mt-6">
           Maybe because London is easy to reach, maybe because the timing was right, maybe both. Cologne was already pretty easy to "sell out", in quotes because MAUI Day has always been free, but London was something else. We had a big waitlist and a lot of excitement around it.
         </p>
+
+        <figure class="my-10 overflow-hidden rounded-3xl border border-gray-200 bg-gray-50 shadow-xl">
+          <img
+            src="https://raw.githubusercontent.com/MauiDay/gallery/main/medium/london-2025/20250314_mauidaylondon_001jpg_54405243109_o.jpg"
+            alt="A larger audience gathered in a lecture room for MAUI Day London 2025."
+            class="w-full object-cover"
+            loading="lazy"
+          />
+          <figcaption class="px-5 py-4 text-sm text-gray-500">
+            MAUI Day London, 2025. Same informal vibe, just with quite a few more people in the room.
+          </figcaption>
+        </figure>
 
         <p class="mt-6">
           That free part is important too. MAUI Day has always been a free event. Sponsors have been kind enough to help with things like lunch, licenses, products to give away, venues, and all the practical things that make a day like this possible. That support is a big reason we can keep it accessible.


### PR DESCRIPTION
## Summary
- add a local history/story page for MAUI Day
- link to it quietly from the archive intro
- keep the new collectible badge callout as the main archive feature

## Validation
- npm run build